### PR TITLE
Avoid adding commented registries in user npmrc

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -353,9 +353,9 @@ def create_user_npmrc
 
   File.delete(npmrc_path) if File.exist?(npmrc_path)
 
-  npmrc = $fetcher.npmrc_content.split
+  npmrc = $fetcher.npmrc_content.split("\n")
   registries = []
-  npmrc.each do |registry| if registry.include?("registry=")
+  npmrc.each do |registry| if !registry.start_with?("#") && registry.include?("registry=")
     registries.push(registry.split('=').at(1).gsub("https:", "").gsub("http:", ""))
   end
   end


### PR DESCRIPTION
This is done to add only the uncommented registries in user npmrc created in dry-run script. 