### PR TITLE
Added dockerfile to build image with only npm related files

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,0 +1,75 @@
+FROM ubuntu:18.04
+
+### SYSTEM DEPENDENCIES
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8"
+
+# Everything from `make` onwards in apt-get install is only installed to ensure
+# Python support works with all packages (which may require specific libraries
+# at install time).
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      dirmngr \
+      git \
+      bzr \
+      mercurial \
+      gnupg2 \
+      curl \
+      wget \
+      zlib1g-dev \
+      liblzma-dev \
+      tzdata \
+      zip \
+      unzip \
+      locales \
+      openssh-client \
+      make \
+      libpq-dev \
+      libssl-dev \
+      libbz2-dev \
+      libffi-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libcurl4-openssl-dev \
+      llvm \
+      libncurses5-dev \
+      libncursesw5-dev \
+      libmysqlclient-dev \
+      xz-utils \
+      tk-dev \
+      libxml2-dev \
+      libxmlsec1-dev \
+      libgeos-dev \
+      python3-enchant \
+    && locale-gen en_US.UTF-8
+
+### RUBY
+
+# Install Ruby 2.6.5, update RubyGems, and install Bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
+    && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu bionic main" > /etc/apt/sources.list.d/brightbox.list \
+    && apt-get update \
+    && apt-get install -y ruby2.6 ruby2.6-dev \
+    && gem update --system 3.0.3 \
+    && gem install bundler -v 1.17.3 --no-document
+
+### JAVASCRIPT
+
+# Install Node 10.0 and Yarn
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install -y yarn
+
+COPY npm_and_yarn/helpers /opt/npm_and_yarn/helpers
+
+ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
+
+RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn


### PR DESCRIPTION
This contains dockerfile to build to the base image for dependabot-core with only npm related changes. Earlier the size was ~3.22GB , now with only npm related files it is ~1.09 GB. 