### PR TITLE
Lerna fix

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -353,7 +353,7 @@ def create_user_npmrc
 
   File.delete(npmrc_path) if File.exist?(npmrc_path)
 
-  npmrc = $fetcher.npmrc_content.gsub("\r\n", "\n").split("\n")
+  npmrc = $fetcher.npmrc_content.gsub("\r\n", "\n").gsub("\r", "\n").split("\n")
   registries = []
   npmrc.each do |registry| if !registry.start_with?("#") && registry.include?("registry=")
     registries.push(registry.split('=').at(1).gsub("https:", "").gsub("http:", ""))

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -353,7 +353,7 @@ def create_user_npmrc
 
   File.delete(npmrc_path) if File.exist?(npmrc_path)
 
-  npmrc = $fetcher.npmrc_content.split("\n")
+  npmrc = $fetcher.npmrc_content.gsub("\r\n", "\n").split("\n")
   registries = []
   npmrc.each do |registry| if !registry.start_with?("#") && registry.include?("registry=")
     registries.push(registry.split('=').at(1).gsub("https:", "").gsub("http:", ""))

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -242,7 +242,7 @@ module Dependabot
 
           OpenStruct.new(
             name: File.basename(entry.fetch("relativePath")),
-            path: entry.fetch("relativePath"),
+            path: path + "/" + entry.fetch("relativePath"),
             type: type,
             size: entry.fetch("size")
           )

--- a/npm_and_yarn/helpers/lib/yarn/updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/updater.js
@@ -174,7 +174,7 @@ async function updateDependencyFile(
   // requirement from the package manifest
   const replacedDeclarationYarnLock = replaceDeclaration(
     originalYarnLock,
-    readFile("yarn.lock"),
+    dedupedYarnLock,
     depName,
     newVersionRequirement,
     existingVersionRequirement

--- a/npm_and_yarn/helpers/lib/yarn/updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/updater.js
@@ -174,7 +174,7 @@ async function updateDependencyFile(
   // requirement from the package manifest
   const replacedDeclarationYarnLock = replaceDeclaration(
     originalYarnLock,
-    dedupedYarnLock,
+    readFile("yarn.lock"),
     depName,
     newVersionRequirement,
     existingVersionRequirement


### PR DESCRIPTION
Bug: The path expecting while identifying various workspace packages for yarn is of the form rootWorkspacesFolder/packageFolderName for e.g if the rootWorkspacesFolder is /packages then package name is midgard-scripting-utils then the expected path is packages/midgard-scripting-utils. But it is only sending back the package name as the path in case of azure.