### PR TITLE
Changed cache folder name for installing packages

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -35,7 +35,7 @@ WORKDIR ${CODE_DIR}
 ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
     BUNDLE_BIN=".bundle/binstubs"
 ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
-ENV NODE_MODULES_ROOT="$CODE_DIR/demo"
+ENV PACKAGES_CACHE_FOLDER="$CODE_DIR/demo"
 
 COPY common/ ${CODE_DIR}/common/
 RUN cd common && bundle install

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -30,7 +30,7 @@ module Dependabot
 
                 def updated_pnpm_lock(pnpm_lock)
                         original_path = Dir.pwd
-                        Dir.chdir(ENV["NODE_MODULES_ROOT"].to_s.strip)
+                        Dir.chdir(ENV["PACKAGES_CACHE_FOLDER"].to_s.strip)
                         write_temporary_dependency_files
                         lockfile_name = Pathname.new(pnpm_lock.name).basename.to_s
                         path = Pathname.new(pnpm_lock.name).dirname.to_s


### PR DESCRIPTION
Renaming the Environment variable NODE_MODULES_ROOT to PACKAGES_CACHE_FOLDER and its reference in pnpm lockfile updater file