### PR TITLE
Added fetching common-version.json for rush

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -136,6 +136,7 @@ module Dependabot
           fetch_file_if_present("common/scripts/install-run-rush.js"),
           fetch_file_if_present("common/scripts/install-run.js"),
           fetch_file_if_present("common/config/pnpmfile-dependencies.json")
+          fetch_file_if_present("common/config/rush/common-versions.json")
         ].compact        
       end
 


### PR DESCRIPTION
This is used to fetch common-version.json file which is used in rush update to restrict version of certain dependencies