### PR TITLE
Azure client: Add support to add new files in a commit

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -73,7 +73,7 @@ module Dependabot
 
         tree_response = get(tree_url)
 
-       JSON.parse(tree_response.body).fetch("objectId")
+        JSON.parse(tree_response.body).fetch("objectId")
       end
 
       def fetch_file_contents(commit, path)

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -134,7 +134,7 @@ module Dependabot
               author: author_details,
               changes: files.map do |file|
                 {
-                  changeType: "edit",
+                  changeType: fetch_repo_contents(base_commit, file.path).length == 1 ? "edit": "add", #else "add", #"edit",
                   item: { path: file.path },
                   newContent: {
                     content: Base64.encode64(file.content),

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -73,7 +73,7 @@ module Dependabot
 
         tree_response = get(tree_url)
 
-        JSON.parse(tree_response.body).fetch("objectId")
+       JSON.parse(tree_response.body).fetch("objectId")
       end
 
       def fetch_file_contents(commit, path)
@@ -134,7 +134,7 @@ module Dependabot
               author: author_details,
               changes: files.map do |file|
                 {
-                  changeType: fetch_repo_contents(base_commit, file.path).length == 1 ? "edit": "add", #else "add", #"edit",
+                  changeType: file_exists?(base_commit, file.path) ? "edit": "add",
                   item: { path: file.path },
                   newContent: {
                     content: Base64.encode64(file.content),
@@ -208,6 +208,21 @@ module Dependabot
 
       private
 
+      def file_exists?(commit, path)
+        # Get the file base and directory name
+        dir = File.dirname(path)
+        basename = File.basename(path)
+
+        # Fetch the contents for the dir and check if there exists any file that matches basename. 
+        # We ignore any sub-dir paths by rejecting "tree" gitObjectType (which is what ADO uses to specify a directory.)
+        fetch_repo_contents(commit, dir)
+            .reject { |f| f["gitObjectType"] == "tree" }
+            .one? { |f| f["relativePath"] == basename}
+
+      rescue Dependabot::Clients::Azure::NotFound
+        # ADO throws exception if dir not found. Return false
+        false
+      end
       attr_reader :credentials
       attr_reader :source
     end


### PR DESCRIPTION
Currently Azure client only supports adding existing files in a commit (using "edit" type). 

This PR adds support for adding a brand new file in a commit ("add" type). This is done by querying ADO to check whether the file in question already exists and picking the appropriate change type.

We use dependabot-core internally at Microsoft to update [Rush ](https://rushjs.io/) monorepos and need this ability to handle [`rush change`](https://rushjs.io/pages/commands/rush_change/) files (which are "new" files created while updating a dependency)