### PR TITLE
Fix for getting metadata for direct dependency update

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -237,7 +237,7 @@ module Dependabot
       def auth_token
         credentials.
           select { |cred| cred["type"] == "npm_registry" }.
-          find { |cred| cred["registry"].include?(dependency_registry) }&.
+          find { |cred| cred["registry"].start_with?(dependency_registry) }&.
           fetch("token", nil)
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -192,6 +192,89 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
       specify { expect { finder.source_url }.to raise_error(JSON::ParserError) }
     end
 
+    context "for a package with private registry source" do
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: {
+              type: "private_registry",
+              url: "https://npm.private-registry.io/dependabot"
+            }
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json")}
+      let(:npm_latest_version_response) {fixture("npm_responses", "etag-1.0.0.json")}
+
+      context 'using Basic authorization' do
+        before do
+          stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
+            with(headers: { "Authorization" => "Basic #{encoded_token}" }).
+            to_return(status: 200, body: npm_latest_version_response)
+        end
+
+        let(:auth_token) {":secretToken"}
+        let(:encoded_token) {Base64.encode64(auth_token).delete("\n")}
+
+        context 'with non encoded token in credentials' do
+          let(:credentials) do
+            [
+              {
+                "type" => "npm_registry",
+                "registry" => "npm.private-registry.io/dependabot",
+                "token" => auth_token
+              }
+            ]
+          end
+
+          it { is_expected.to eq("https://github.com/jshttp/etag") }
+        end
+
+        context 'with encoded token in credentials' do
+          let(:credentials)  do
+            [
+              {
+                "type" => "npm_registry",
+                "registry" => "npm.private-registry.io/dependabot",
+                "token" => encoded_token
+              }
+            ]
+          end
+
+          it { is_expected.to eq("https://github.com/jshttp/etag") }
+        end
+      end
+
+      context 'using Bearer authorization' do
+        before do
+          stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
+            with(headers: { "Authorization" => "Bearer secret_token" }).
+            to_return(status: 200, body: npm_latest_version_response)
+        end
+
+        let(:credentials)  do
+          [
+            {
+              "type" => "npm_registry",
+              "registry" => "npm.private-registry.io/dependabot",
+              "token" => "secret_token"
+            }
+          ]
+        end
+
+        it { is_expected.to eq("https://github.com/jshttp/etag") }
+      end
+
+    end
+
     context "for a scoped package name" do
       before do
         stub_request(:get, "https://registry.npmjs.org/@etag%2Fetag/latest").

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -211,18 +211,17 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
         )
       end
 
-      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json")}
-      let(:npm_latest_version_response) {fixture("npm_responses", "etag-1.0.0.json")}
+      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json") }
+      let(:npm_latest_version_response) { fixture("npm_responses", "etag-1.0.0.json") }
+
+      let(:auth_token) {":secretToken"}
+      let(:encoded_token) { Base64.encode64(auth_token).delete("\n")  }
+
+      stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
+          with(headers: { "Authorization" => "Basic #{encoded_token}" }).
+          to_return(status: 200, body: npm_latest_version_response)
 
       context 'using Basic authorization' do
-        before do
-          stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
-            with(headers: { "Authorization" => "Basic #{encoded_token}" }).
-            to_return(status: 200, body: npm_latest_version_response)
-        end
-
-        let(:auth_token) {":secretToken"}
-        let(:encoded_token) {Base64.encode64(auth_token).delete("\n")}
 
         context 'with non encoded token in credentials' do
           let(:credentials) do
@@ -254,11 +253,9 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
       end
 
       context 'using Bearer authorization' do
-        before do
-          stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
-            with(headers: { "Authorization" => "Bearer secret_token" }).
-            to_return(status: 200, body: npm_latest_version_response)
-        end
+        stub_request(:get, "https://npm.private-registry.io/dependabot/etag/latest").
+          with(headers: { "Authorization" => "Bearer secret_token" }).
+          to_return(status: 200, body: npm_latest_version_response)
 
         let(:credentials)  do
           [


### PR DESCRIPTION
For direct dependency update, dependabot-core was unable to fetch metadata such as release notes, changelog,etc from the private registry.  Added fix for two issues because of which it was unable to fetch metadata- 
1) While getting auth token for authenticating the get request to fetch version details, it does an equality check on the registry url for the package mentioned in the lockfile and credentials array ( which created from the .npmrc file). So in the .npmrc file, there is an extra '/' at the end because of which this equality check fails and no valid auth token is returned. Added an include check while comparing the registry urls.
2) After solving the above equality check, authorization headers for the get request were Bearer authorization whereas the tokens used by DmaasCore were to be used for Basic authentication. Added logic to choose the headers based on the auth token obtained from the auth_token method.