### PR TITLE
PR description limit exceeded error in azure devops

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -153,13 +153,15 @@ module Dependabot
 
       def create_pull_request(pr_name, source_branch, target_branch,
                               pr_description, labels)
-        # Azure DevOps only support descriptions up to 4000 characters
+        # Azure DevOps only support descriptions up to 4000 characters in UTF-16 encoding
         # https://developercommunity.visualstudio.com/content/problem/608770/remove-4000-character-limit-on-pull-request-descri.html
         azure_max_length = 3999
-        if pr_description.length > azure_max_length
+
+        if get_pr_description_length(pr_description) > azure_max_length
           truncated_msg = "...\n\n_Description has been truncated_"
           truncate_length = azure_max_length - truncated_msg.length
-          pr_description = pr_description[0..truncate_length] + truncated_msg
+          end_index = get_description_end_index(pr_description, truncate_length)
+          pr_description = end_index == -1 ? "" : pr_description[0..end_index]  + truncated_msg
         end
 
         puts "Create pull request from source: #{source_branch} to target: #{target_branch}"
@@ -207,6 +209,32 @@ module Dependabot
       end
 
       private
+
+      # Get pr description length in UTF-16 encoding.
+      def get_pr_description_length(pr_description)
+        length = 0
+        pr_description.each_char{|c|
+          length += (c.bytesize/2 + c.bytesize%2)
+        }
+        length
+      end
+
+      # Get the end index for pr description according to the maximum length in UTF-16 encoding.
+      def get_description_end_index(description, max_length)
+        length = 0
+        index = -1
+        description.each_char{|c|
+          character_length = c.bytesize/2 + c.bytesize%2
+          if length + character_length > max_length
+            break
+          end
+
+          length += character_length
+          index += 1
+        }
+
+        index
+      end
 
       def file_exists?(commit, path)
         # Get the file base and directory name


### PR DESCRIPTION
Faced an issue where in PR creation failed because the PR description limit (i.e 4000 characters in ADO) was exceeded when the pr description length calculated in dependabot-core was less than 4000. This is was due to a special unicode character i.e 🎉 which in UTF-8 (encoding used in dependabot-core) had length 1 whereas on ADO side which used UTF-16 encoding, the size for this character was calculated to be 2 because of which the character limit got exceeded while PR creation. Added a method to get the end index for pr description based on the length of each character in UTF-16 encoding 