### PR TITLE
Correctly handle errors for rush:update

### DIFF
--- a/npm_and_yarn/helpers/lib/rush/updater.js
+++ b/npm_and_yarn/helpers/lib/rush/updater.js
@@ -4,15 +4,18 @@ var exec = require('child_process').exec, child;
 
 async function runRushUpdate(rootPath, shrinkwrapFilePath){
 
-    return new Promise(resolve => {
+    return new Promise( (resolve, reject)  => {
     
-        exec('node common/scripts/install-run-rush.js update --no-link --bypass-policy', { maxBuffer: 1024 * 1024 * 50 }, function(a,b,c) {
+        exec('node common/scripts/install-run-rush.js update --no-link --bypass-policy', { maxBuffer: 1024 * 1024 * 50 }, function(err, stdout, stderr) {
+            if(err){ 
+                err.message += (stdout + stderr);
+                reject(err);
+            }
+
             const updateFileContent = fs.readFileSync(path.join(rootPath, shrinkwrapFilePath)).toString()
-            // return { shrinkwrapFilePath: updateFileContent };
             return resolve(updateFileContent);
         });
-    },
-    //  TODO: Handle error as well 
-    () => {});
+    });
 }
+
 module.exports = { runRushUpdate }

--- a/npm_and_yarn/helpers/lib/rush/updater.js
+++ b/npm_and_yarn/helpers/lib/rush/updater.js
@@ -6,7 +6,7 @@ async function runRushUpdate(rootPath, shrinkwrapFilePath){
 
     return new Promise( (resolve, reject)  => {
     
-        exec('node common/scripts/install-run-rush.js update --no-link --bypass-policy', { maxBuffer: 1024 * 1024 * 50 }, function(err, stdout, stderr) {
+        exec('node common/scripts/install-run-rush.js update --bypass-policy', { maxBuffer: 1024 * 1024 * 50 }, function(err, stdout, stderr) {
             if(err){ 
                 err.message += (stdout + stderr);
                 reject(err);

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -39,27 +39,21 @@ module Dependabot
                             lockfile_name: lockfile_name
                         )
                         Dir.chdir(original_path)
-                        return response
-                        # updated_files.fetch(lockfile_name)
-                rescue SharedHelpers::HelperSubprocessFailed => e
-                    puts "#{e}"
-                #     handle_pnpm_lock_updater_error(e, pnpm_lock)
+
+                        response
                 end
                 
                 # TODO: Currently works only for a single file (pnpms's shrinkwrap.yaml). Update the params to take a list of file paths that need to be reread 
                 # after we run rush update.
                 def run_rush_updater(path:, lockfile_name:)
-                    #puts "#{Dir.pwd}"
                     SharedHelpers.run_helper_subprocess(
                         command: NativeHelpers.helper_path,
                         function: "rush:update",
                         args: [
                             Dir.pwd,
                             path+"/"+lockfile_name
-                        # top_level_dependency_updates
                         ]
                     )
-
                 end
 
                 def run_current_rush_update(path:, lockfile_name:)
@@ -93,10 +87,6 @@ module Dependabot
                     end
                     
                 end
-                
-                # def package_files
-                #     dependency_files.select { |f| f.name.end_with?("package.json") }
-                # end
 
                 def top_level_dependencies
                     @dependencies.select(&:top_level?)


### PR DESCRIPTION
- Errors thrown by rush:update were being ignored.
- Cleaned up some other code as well.
- Remove "--no-link" option due to which Rush update was failing.