### PR TITLE
Throw error if lockfile not updated after rush update

### DIFF
--- a/npm_and_yarn/helpers/lib/rush/updater.js
+++ b/npm_and_yarn/helpers/lib/rush/updater.js
@@ -8,7 +8,6 @@ async function runRushUpdate(rootPath, shrinkwrapFilePath){
     
         exec('node common/scripts/install-run-rush.js update --bypass-policy', { maxBuffer: 1024 * 1024 * 50 }, function(err, stdout, stderr) {
             if(err){ 
-                err.message += (stdout + stderr);
                 reject(err);
             }
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -117,7 +117,7 @@ module Dependabot
       def pnpm_locks
         @pnpm_locks ||=
           dependency_files
-          .select { |f| ["common/config/rush/pnpm-lock.yaml", "common/config/rush/shrinkwrap.yaml"].include?(f.name) } # Check for Rush pnpn lock file paths. We do not support non-Rush pnpm projects yet.
+          .select { |f| ["common/config/rush/pnpm-lock.yaml", "common/config/rush/shrinkwrap.yaml"].include?(f.name) } # Check for Rush pnpm lock file paths. We do not support non-Rush pnpm projects yet.
       end
 
       def yarn_lock_changed?(yarn_lock)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -117,7 +117,7 @@ module Dependabot
       def pnpm_locks
         @pnpm_locks ||=
           dependency_files
-          .select { |f| f.name.end_with?("pnpm-lock.yaml", "shrinkwrap.yaml") }
+          .select { |f| ["common/config/rush/pnpm-lock.yaml", "common/config/rush/shrinkwrap.yaml"].include?(f.name) } # Check for Rush pnpn lock file paths. We do not support non-Rush pnpm projects yet.
       end
 
       def yarn_lock_changed?(yarn_lock)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -22,9 +22,6 @@ module Dependabot
                     end
             
                     updated_pnpm_lock(pnpm_lock_file)
-            
-                    # @updated_pnpm_lock_content[pnpm_lock_file.name] =
-                    #     post_process_pnpm_lock_file(new_content)
                 end
 
 
@@ -40,10 +37,12 @@ module Dependabot
                         )
                         Dir.chdir(original_path)
 
+                        raise "Failed to update #{lockfile_name}: Content not changed." if response == pnpm_lock.content
+
                         response
                 end
                 
-                # TODO: Currently works only for a single file (pnpms's shrinkwrap.yaml). Update the params to take a list of file paths that need to be reread 
+                # TODO: Currently works only for a single file (pnpms's shrinkwrap.yaml/pnpm-lock.yaml). Update the params to take a list of file paths that need to be reread
                 # after we run rush update.
                 def run_rush_updater(path:, lockfile_name:)
                     SharedHelpers.run_helper_subprocess(


### PR DESCRIPTION
Sometime "rush update" exits with non-zero error code, even when it fails (For example, when there is a node engine version mismatch). 

Added an extra check that will raise an error if lockfile content is not changed after "rush update" step.