### PR TITLE
Pull request updater for azure client

### DIFF
--- a/common/lib/dependabot/pull_request_updater.rb
+++ b/common/lib/dependabot/pull_request_updater.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/pull_request_updater/github"
 require "dependabot/pull_request_updater/gitlab"
+require "dependabot/pull_request_updater/azure"
 
 module Dependabot
   class PullRequestUpdater
@@ -27,6 +28,7 @@ module Dependabot
       case source.provider
       when "github" then github_updater.update
       when "gitlab" then gitlab_updater.update
+      when "azure" then azure_updater.update
       else raise "Unsupported provider #{source.provider}"
       end
     end
@@ -48,6 +50,17 @@ module Dependabot
 
     def gitlab_updater
       Gitlab.new(
+        source: source,
+        base_commit: base_commit,
+        old_commit: old_commit,
+        files: files,
+        credentials: credentials,
+        pull_request_number: pull_request_number
+      )
+    end
+
+    def azure_updater
+      Azure.new(
         source: source,
         base_commit: base_commit,
         old_commit: old_commit,

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "dependabot/clients/azure"
+
+module Dependabot
+    class PullRequestUpdater
+        class Azure
+            attr_reader :source, :files, :base_commit, :old_commit, :credentials,
+                  :pull_request_number
+
+            def initialize(source:, base_commit:, old_commit:, files:,
+                            credentials:, pull_request_number:)
+                @source              = source
+                @base_commit         = base_commit
+                @old_commit          = old_commit
+                @files               = files
+                @credentials         = credentials
+                @pull_request_number = pull_request_number
+            end
+
+            def update
+                return unless pull_request && source_branch_name
+                update_source_branch
+            end
+
+            private
+
+            def azure_client_for_source
+                @azure_client_for_source ||=
+                Dependabot::Clients::Azure.for_source(
+                    source: source,
+                    credentials: credentials
+                )
+            end
+
+            def pull_request
+                @pull_request ||=
+                azure_client_for_source.get_pull_request(pull_request_number)
+            end
+
+            def source_branch_name
+                @source_branch_name ||=
+                pull_request.fetch('sourceRefName').gsub('refs/heads/', '')
+            end
+
+            def update_source_branch
+                azure_client_for_source.create_commit(
+                    source_branch_name, 
+                    old_commit, 
+                    "Bumps dependency",
+                    files,
+                    nil
+                )
+            end
+
+        end
+    end
+end
+

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -3,57 +3,108 @@
 require "dependabot/clients/azure"
 
 module Dependabot
-    class PullRequestUpdater
-        class Azure
-            attr_reader :source, :files, :base_commit, :old_commit, :credentials,
+  class PullRequestUpdater
+    class Azure
+      OBJECT_ID_FOR_BRANCH_DELETE = "0000000000000000000000000000000000000000"
+
+      attr_reader :source, :files, :base_commit, :old_commit, :credentials,
                   :pull_request_number
 
-            def initialize(source:, base_commit:, old_commit:, files:,
-                            credentials:, pull_request_number:)
-                @source              = source
-                @base_commit         = base_commit
-                @old_commit          = old_commit
-                @files               = files
-                @credentials         = credentials
-                @pull_request_number = pull_request_number
-            end
+      def initialize(source:, files:, base_commit:, old_commit:,
+                     credentials:, pull_request_number:)
+        @source = source
+        @files = files
+        @base_commit = base_commit
+        @old_commit = old_commit
+        @credentials = credentials
+        @pull_request_number = pull_request_number
+      end
 
-            def update
-                return unless pull_request && source_branch_name
-                update_source_branch
-            end
+      def update
+        return unless pull_request_exists? && source_branch_exists?
 
-            private
+        update_source_branch
+      end
 
-            def azure_client_for_source
-                @azure_client_for_source ||=
-                Dependabot::Clients::Azure.for_source(
-                    source: source,
-                    credentials: credentials
-                )
-            end
+      private
 
-            def pull_request
-                @pull_request ||=
-                azure_client_for_source.get_pull_request(pull_request_number)
-            end
+      def azure_client_for_source
+        @azure_client_for_source ||=
+          Dependabot::Clients::Azure.for_source(
+            source: source,
+            credentials: credentials
+          )
+      end
 
-            def source_branch_name
-                @source_branch_name ||=
-                pull_request.fetch('sourceRefName').gsub('refs/heads/', '')
-            end
+      def pull_request_exists?
+        pull_request
+      rescue Dependabot::Clients::Azure::NotFound
+        false
+      end
 
-            def update_source_branch
-                azure_client_for_source.create_commit(
-                    source_branch_name, 
-                    old_commit, 
-                    "Bumps dependency",
-                    files,
-                    nil
-                )
-            end
+      def source_branch_exists?
+        azure_client_for_source.branch(source_branch_name)
+      rescue Dependabot::Clients::Azure::NotFound
+        false
+      end
 
-        end
+      # Currently the PR diff in ADO shows difference in commits instead of actual diff in files.
+      # This workaround is done to get the target branch commit history on the source branch alongwith file changes
+      def update_source_branch
+        # 1) Push the file changes to a newly created temporary branch (from base commit)
+        new_commit = create_temp_branch
+        # 2) Update PR source branch to point to the temp branch head commit.
+        update_branch(source_branch_name, old_source_branch_commit, new_commit)
+        # 3) Delete temp branch
+        update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
+      end
+
+      def pull_request
+        @pull_request ||=
+          azure_client_for_source.fetch_pull_request(pull_request_number.to_s)
+      end
+
+      def source_branch_name
+        @source_branch_name ||= pull_request&.fetch("sourceRefName")&.gsub("refs/heads/", "")
+      end
+
+      def create_temp_branch
+        response = azure_client_for_source.create_commit(
+          temp_branch_name,
+          base_commit,
+          commit_message,
+          files,
+          nil
+        )
+
+        JSON.parse(response.body).fetch("refUpdates").first.fetch("newObjectId")
+      end
+
+      def temp_branch_name
+        "#{source_branch_name}-temp"
+      end
+
+      def update_branch(branch_name, old_commit, new_commit)
+        azure_client_for_source.update_ref(
+          branch_name,
+          old_commit,
+          new_commit
+        )
+      end
+
+      # For updating source branch, we require the latest commit for the source branch.
+      def commit_being_updated
+        @commit_being_updated ||=
+          azure_client_for_source.commits(source_branch_name).first
+      end
+
+      def old_source_branch_commit
+        commit_being_updated.fetch("commitId")
+      end
+
+      def commit_message
+        commit_being_updated.fetch("comment")
+      end
     end
+  end
 end
-

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -127,6 +127,77 @@ RSpec.describe Dependabot::Clients::Azure do
     end
   end
 
+  describe "#fetch_pull_request" do
+    subject { client.fetch_pull_request(pull_request_id) }
+
+    let(:pull_request_id) { "1" }
+    let(:pull_request_url) { base_url + "/_apis/git/pullrequests/#{pull_request_id}" }
+
+    context "when response is 200" do
+      response_body = fixture("azure", "pull_request_details.json")
+
+      before do
+        stub_request(:get, pull_request_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 200, body: response_body)
+      end
+
+      specify { expect { subject }.to_not raise_error }
+
+      it { is_expected.to eq(JSON.parse(response_body)) }
+    end
+
+    context "when response is 404" do
+      before do
+        stub_request(:get, pull_request_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 404)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::NotFound)
+      end
+    end
+  end
+
+  describe "#update_ref" do
+    subject(:update_ref) do
+      client.update_ref(
+        branch,
+        old_commit_id,
+        new_commit_id
+      )
+    end
+
+    let(:old_commit_id) { "oldcommitsha" }
+    let(:new_commit_id) { "newcommitsha" }
+    let(:update_ref_url) { repo_url + "/refs?api-version=5.0" }
+
+    it "sends update branch request with old and new commit id" do
+      stub_request(:post, update_ref_url).
+        with(basic_auth: [username, password]).
+        to_return(status: 200)
+
+      update_ref
+
+      expect(WebMock).
+        to(
+          have_requested(:post, update_ref_url).
+            with do |req|
+              json_body = JSON.parse(req.body)
+              expect(json_body.count).to eq(1)
+              ref_update_details = json_body.first
+              expect(ref_update_details.fetch("name")).
+                to eq("refs/heads/#{branch}")
+              expect(ref_update_details.fetch("oldObjectId")).
+                to eq(old_commit_id)
+              expect(ref_update_details.fetch("newObjectId")).
+                to eq(new_commit_id)
+            end
+        )
+    end
+  end
+
   describe "#get" do
     context "Using auth headers" do
       token = ":test_token"

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/pull_request_updater/azure"
+
+RSpec.describe Dependabot::PullRequestUpdater::Azure do
+  subject(:updater) do
+    described_class.new(
+      source: source,
+      base_commit: base_commit,
+      old_commit: old_commit,
+      files: files,
+      credentials: credentials,
+      pull_request_number: pull_request_number
+    )
+  end
+
+  let(:org) { "org" }
+  let(:project) { "project" }
+  let(:repo_name) { "repo" }
+  let(:source) do
+    Dependabot::Source.new(provider: "azure", repo: "#{org}/#{project}/_git/#{repo_name}")
+  end
+  let(:files) { [gemfile, gemspec] }
+  let(:base_commit) { "basecommitsha" }
+  let(:old_commit) { "oldcommitsha" }
+  let(:source_branch_old_commit) { "9c8376e9b2e943c2c72fac4b239876f377f0305a" }
+  let(:source_branch_new_commit) { "newcommitsha" }
+  let(:tree_object_id) { "treeobjectid" }
+  let(:pull_request_number) { 1 }
+  let(:source_branch) { "dependabot/npm_and_yarn/business-1.5.0" }
+  let(:temp_branch) { source_branch + "-temp" }
+  let(:path) { "files/are/here" }
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "dev.azure.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+
+  let(:gemfile) do
+    Dependabot::DependencyFile.new(
+      name: "Gemfile",
+      content: fixture("ruby", "gemfiles", "Gemfile"),
+      directory: path
+    )
+  end
+  let(:gemspec) do
+    Dependabot::DependencyFile.new(
+      name: "test.gemspec",
+      content: fixture("ruby", "gemspecs", "example"),
+      directory: path
+    )
+  end
+
+  let(:commit_message) { "Added example file" }
+  let(:json_header) { { "Content-Type" => "application/json" } }
+  let(:source_api_endpoint) { "https://dev.azure.com" }
+  let(:repo_url) { "#{source_api_endpoint}/#{org}/#{project}/_apis/git/repositories/#{repo_name}" }
+  let(:pull_request_url) { "#{source_api_endpoint}/#{org}/#{project}/_apis/git/pullrequests/#{pull_request_number}" }
+  let(:source_branch_url) { repo_url + "/refs?filter=heads/#{source_branch}" }
+  let(:source_branch_commits_url) { repo_url + "/commits?searchCriteria.itemVersion.version=#{source_branch}" }
+  let(:repo_contents_tree_url) do
+    repo_url + "/items?path=/#{path}&versionDescriptor.version=#{base_commit}&versionDescriptor.versionType=commit"
+  end
+  let(:repo_contents_url) { repo_url + "/trees/#{tree_object_id}?recursive=false" }
+  let(:create_commit_url) { repo_url + "/pushes?api-version=5.0" }
+  let(:branch_update_url) { repo_url + "/refs?api-version=5.0" }
+
+  before do
+    stub_request(:get, pull_request_url).
+      to_return(status: 200,
+                body: fixture("azure", "pull_request_details.json"),
+                headers: json_header)
+    stub_request(:get, source_branch_url).
+      to_return(status: 200,
+                body: fixture("azure", "pull_request_source_branch_details.json"),
+                headers: json_header)
+    stub_request(:post, "#{repo_url}/pushes?api-version=5.0").
+      to_return(status: 201,
+                headers: json_header)
+  end
+
+  describe "#update" do
+    context "when the PR doesn't exist" do
+      before { stub_request(:get, pull_request_url).to_return(status: 404) }
+
+      it "doesn't update source branch head commit in AzureDevOps" do
+        updater.update
+        expect(WebMock).
+          to_not have_requested(:post, branch_update_url)
+      end
+
+      it "returns nil" do
+        expect(updater.update).to be_nil
+      end
+    end
+
+    context "when the branch doesn't exist" do
+      before { stub_request(:get, source_branch_url).to_return(status: 404) }
+
+      it "doesn't update source branch head commit in AzureDevOps" do
+        updater.update
+        expect(WebMock).
+          to_not have_requested(:post, branch_update_url)
+      end
+
+      it "returns nil" do
+        expect(updater.update).to be_nil
+      end
+    end
+
+    it "updates source branch head commit in AzureDevOps" do
+      stub_request(:get, source_branch_commits_url).
+        to_return(status: 200,
+                  body: fixture("azure", "commits.json"),
+                  headers: json_header)
+      stub_request(:get, repo_contents_tree_url).
+        to_return(status: 200,
+                  body: fixture("azure", "repo_contents_treeroot.json"),
+                  headers: json_header)
+      stub_request(:get, repo_contents_url).
+        to_return(status: 200,
+                  body: fixture("azure", "repo_contents.json"),
+                  headers: json_header)
+      stub_request(:post, create_commit_url).
+        with(body: {
+               refUpdates: [
+                 { name: "refs/heads/#{temp_branch}", oldObjectId: base_commit }
+               ],
+               commits: [
+                 {
+                   comment: commit_message,
+                   changes: files.map do |file|
+                     {
+                       changeType: "edit",
+                       item: { path: file.path },
+                       newContent: {
+                         content: Base64.encode64(file.content),
+                         contentType: "base64encoded"
+                       }
+                     }
+                   end
+                 }
+               ]
+             }).
+        to_return(status: 201,
+                  body: fixture("azure", "create_new_branch.json"),
+                  headers: json_header)
+      stub_request(:post, branch_update_url).
+        to_return(status: 201)
+
+      updater.update
+
+      expect(WebMock).
+        to(
+          have_requested(:post, branch_update_url).
+              with(body: [
+                { name: "refs/heads/#{source_branch}", oldObjectId: source_branch_old_commit,
+                  newObjectId: source_branch_new_commit }
+              ].to_json)
+        )
+    end
+  end
+end

--- a/common/spec/fixtures/azure/create_new_branch.json
+++ b/common/spec/fixtures/azure/create_new_branch.json
@@ -1,0 +1,9 @@
+{
+    "refUpdates":[
+        {
+            "name": "refs/heads/dependabot/npm_and_yarn/business-1.5.0-temp",
+            "oldObjectId": "0000000000000000000000000000000000000000",
+            "newObjectId": "newcommitsha"
+        }
+    ]
+}

--- a/common/spec/fixtures/azure/pull_request_details.json
+++ b/common/spec/fixtures/azure/pull_request_details.json
@@ -1,0 +1,3 @@
+{
+    "sourceRefName" : "refs/heads/dependabot/npm_and_yarn/business-1.5.0"
+}

--- a/common/spec/fixtures/azure/pull_request_details.json
+++ b/common/spec/fixtures/azure/pull_request_details.json
@@ -1,3 +1,7 @@
 {
-    "sourceRefName" : "refs/heads/dependabot/npm_and_yarn/business-1.5.0"
+    "id":"854e434d-b904-664a-b566-2d668372940c",
+    "uniqueName":"abc@xyz.com",
+    "title":"Bumps business",
+    "sourceRefName":"refs/heads/dependabot/npm_and_yarn/business-1.5.0",
+    "targetRefName":"refs/heads/master"
 }

--- a/common/spec/fixtures/azure/pull_request_source_branch_details.json
+++ b/common/spec/fixtures/azure/pull_request_source_branch_details.json
@@ -1,0 +1,23 @@
+{
+    "value": [
+        {
+            "name": "refs/heads/dependabot/npm_and_yarn/business-1.5.0",
+            "objectId": "9c8376e9b2e943c2c72fac4b239876f377f0305a",
+            "creator": {
+                "displayName": "Bob Jones",
+                "url": "https://app.vssps.visualstudio.com/A3aa6c2ad-bb93-43c9-b957-ef1b14cf6ada/_apis/Identities/5ca0c171-a590-4ceb-a8d4-36c593907c1a",
+                "_links": {
+                    "avatar": {
+                        "href": "https://dev.azure.com/org/_apis/GraphProfile/MemberAvatars/aad.MTRjNTllMmQtODU2Yi03OTZlLThjZGQtZmU0ZTVhYWUyNGNa"
+                    }
+                },
+                "id": "5ca0c171-a590-4ceb-a8d4-36c593907c1a",
+                "uniqueName": "Bob.Jones@org.com",
+                "imageUrl": "https://dev.azure.com/org/_api/_common/identityImage?id=5ca0c171-a590-4ceb-a8d4-36c593907c1a",
+                "descriptor": "aad.MTRjNTllMmQtODU2Yi03OTZlLThjZGQtZmU0ZTVhYWUyNGNa"
+            },
+            "url": "https://dev.azure.com/org/8929b42a-8f67-4075-bdb1-908ea8ebfb3a/_apis/git/repositories/3c492e10-aa73-4855-b11e-5d6d9bd7d03a/refs?filter=heads%2Fdependabot%2Fnpm_and_yarn%2Fbusiness-1.5.0"
+        }
+    ],
+    "count": 1
+}

--- a/common/spec/fixtures/azure/repo_contents.json
+++ b/common/spec/fixtures/azure/repo_contents.json
@@ -1,0 +1,37 @@
+{
+    "objectId":"treeobjectid",
+    "url":"https://dev.azure.com/org/project/_apis/git/repositories/repo/trees/c3f6adf854087e2bb23b91f7a16a539af23b63bf",
+    "treeEntries":[
+       {
+          "objectId":"52f1692bcfa9b3e5bb8fce18295a2e97de74ed98",
+          "relativePath":".config",
+          "mode":"40000",
+          "gitObjectType":"tree",
+          "url":"https://dev.azure.com/office/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/trees/52f1692bcfa9b3e5bb8fce18295a2e97de74ed98",
+          "size":37
+       },
+       {
+          "objectId":"8fbfd693f834dac11658863f6d4bcaea0c07e93f",
+          "relativePath":"Gemfile",
+          "mode":"100644",
+          "gitObjectType":"blob",
+          "url":"https://dev.azure.com/office/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/blobs/8fbfd693f834dac11658863f6d4bcaea0c07e93f",
+          "size":800
+       },
+       {
+          "objectId":"ab3ae17079e5c299ce26f0feed8dd3215427c5f7",
+          "relativePath":".npmrc",
+          "mode":"100644",
+          "gitObjectType":"blob",
+          "url":"https://dev.azure.com/office/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/blobs/ab3ae17079e5c299ce26f0feed8dd3215427c5f7",
+          "size":575
+       },
+       {
+          "objectId":"39ba713f8b994fb1ec7dda5df2f78ca1a55c3237",
+          "relativePath":"test.gemspec",
+          "mode":"100644",
+          "gitObjectType":"blob",
+          "url":"https://dev.azure.com/office/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/trees/39ba713f8b994fb1ec7dda5df2f78ca1a55c3237",
+          "size":6672
+       }]
+}

--- a/common/spec/fixtures/azure/repo_contents_treeroot.json
+++ b/common/spec/fixtures/azure/repo_contents_treeroot.json
@@ -1,0 +1,19 @@
+{
+    "objectId":"treeobjectid",
+    "gitObjectType":"tree",
+    "commitId":"9c8376e9b2e943c2c72fac4b239876f377f0305a",
+    "path":"/files/are/here",
+    "isFolder":true,
+    "url":"https://dev.azure.com/org/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/items?path=files%2Fare%2Fhere&versionType=Commit&version=9c8376e9b2e943c2c72fac4b239876f377f0305a&versionOptions=None",
+    "_links":{
+       "self":{
+          "href":"https://dev.azure.com/org/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/items?path=files%2Fare%2Fhere&versionType=Commit&version=9c8376e9b2e943c2c72fac4b239876f377f0305a&versionOptions=None"
+       },
+       "repository":{
+          "href":"https://dev.azure.com/org/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d"
+       },
+       "tree":{
+          "href":"https://dev.azure.com/org/e853b87d-318c-4879-bedc-5855f3483b54/_apis/git/repositories/97faf8b7-6265-4fd5-b5e8-16abad20f98d/trees/c3f6adf854087e2bb23b91f7a16a539af23b63bf"
+       }
+    }
+ }


### PR DESCRIPTION
# Feature
Added support for updating pull requests for `azure client (AzureDevOps)`. For updating pull requests (i.e pushing new file changes) implemented the following logic - 

- Check if the `PR & PR source branch` exists. If no, return nil else continue
- Push the new file changes onto the PR source branch.

`Caveat` - Currently the AzureDevOps PR files diff UI shows the diff in commits instead of the actual diff in the file content. Hence, there is a temporary workaround to push file changes to the source branch to ensure the reviewer sees the exact files changes. The workaround is as follows - 

- Create a new temp branch from the PR target branch and push the new file changes in that branch.
- Update the PR source branch head commit to this newly created branch head commit(hence preserving the commit history and pushing the new file changes)
- Delete the temp branch

# Testing
Added unit tests for the pull request updater implementation for azure client as well as the additional methods added in the azure client class.