### PR TITLE
Modify required files check in file parser and updater

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -124,7 +124,7 @@ module Dependabot
       end
 
       def check_required_files
-        raise "No package.json!" unless get_original_file("package.json")
+        raise "No manifest file!" unless get_original_file("package.json") || get_original_file("rush.json")
       end
 
       def ignore_requirement?(requirement)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -78,7 +78,7 @@ module Dependabot
       end
 
       def check_required_files
-        raise "No package.json!" unless get_original_file("package.json")
+        raise "No manifest file!" unless get_original_file("package.json") || get_original_file("rush.json")
       end
 
       def error_context(updated_files:)


### PR DESCRIPTION
This PR modifies the check on required files in file parser and updater for npm and yarn to raise an error when the repo root directory does not have a package.json or rush.json. 
`NOTE`: This is an additional change required to make package.json optional in case of rush repos.