### PR TITLE
Modified update workflow for yarn update for direct dependencies

### DIFF
--- a/npm_and_yarn/helpers/lib/yarn/replace-lockfile-declaration.js
+++ b/npm_and_yarn/helpers/lib/yarn/replace-lockfile-declaration.js
@@ -40,7 +40,7 @@ module.exports = (
   const newPackageReqs = getRequestedVersions(depName, newJson);
 
   const reqToReplace = newPackageReqs.find((pattern) => {
-    return !oldPackageReqs.includes(pattern);
+    return pattern !== newVersionRequirement && !oldPackageReqs.includes(pattern);
   });
 
   // If the new lockfile has entries that don't exist in the old lockfile,

--- a/npm_and_yarn/helpers/lib/yarn/updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/updater.js
@@ -165,6 +165,21 @@ async function updateDependencyFile(
   // Despite the innocent-sounding name, this actually does all the hard work
   await add.init();
 
+  // NOTE: currently for yarn v1, `add` command does not handle "resolutions" in package.json and this leads to addition of unrelated dependency updates in lockfile.
+  // Hence we have changed the update workflow for yarn from dependabot-core to avoid these unrelated updates.
+  // Instead of using `yarn add` to make the changes in the lockfile, we will be using `yarn install` command.
+
+  // Revert changes in lockfile due to yarn add to allow yarn install to make only relevant changes to the lockfile.
+  fs.writeFileSync(
+    path.join(directory, "yarn.lock"),
+    originalYarnLock
+  );
+
+  // Run install to add changes in lockfile according to "resolutions" and current version update in manifest file.
+  const lockfile2 = await Lockfile.fromDirectory(directory, reporter);
+  const install2 = new LightweightInstall(flags, config, reporter, lockfile2);
+  await install2.init();
+
   const dedupedYarnLock = fixDuplicates(readFile("yarn.lock"), depName);
 
   const newVersionRequirement = requirements.requirement;
@@ -190,10 +205,6 @@ async function updateDependencyFile(
     path.join(directory, requirements.file),
     originalPackageJson
   );
-
-  const lockfile2 = await Lockfile.fromDirectory(directory, reporter);
-  const install2 = new LightweightInstall(flags, config, reporter, lockfile2);
-  await install2.init();
 
   let updatedYarnLock = readFile("yarn.lock");
   updatedYarnLock = recoverVersionComments(originalYarnLock, updatedYarnLock);


### PR DESCRIPTION
Fix for dependabot-core issue: https://github.com/dependabot/dependabot-core/issues/4063

Original update workflow for yarn v1 in dependabot-core - 

1. `yarn add dependency@new-version` in the workspace project folder
2. `yarn dedupe`
3. `yarn install`

Updated workflow to avoid unrelated package update for "resolutions" packages - 

1. yarn add dependency@new-version in the workspace project folder
2. revert changes in lockfile due to yarn add
3. yarn install (this step would now only update the lockfile for the new dependency version)
4. yarn dedupe

Overall, the idea here is to use `yarn install` command to make changes to the lockfile instead of the previously used `yarn add`. Tested this on our existing customer repos like OneShell