### PR TITLE
Handle .tar path dependencies

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -645,6 +645,79 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         end
       end
     end
+    
+    context "with a tar path dependency" do
+      before do
+        stub_request(:get, File.join(url, "package.json?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "package_json_with_tar_path.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                           "contents/deps/etag.tar?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 403,
+            body: fixture("github", "file_too_large.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                            "contents/deps?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_js_tar.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/git/"\
+                           "blobs/2393602fac96cfe31d64f89476014124b4a13b85").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "blob_js_tarball.json"),
+            headers: json_header
+          )
+      end
+
+      it "fetches the tarball path dependency" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(
+          ["package.json", "package-lock.json", "deps/etag.tar"]
+        )
+      end
+    end
+
+    context "that has an unfetchable tar path dependency" do
+      before do
+        stub_request(:get, File.join(url, "package.json?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "package_json_with_tar_path.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                            "contents/deps?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_js_tar.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                          "contents/deps/etag.tar?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404)
+      end
+
+      it "doesn't try to fetch the tar as a package" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(
+          ["package.json", "package-lock.json"]
+        )
+      end
+    end
+
   end
 
   context "with a path dependency in a yarn resolution" do

--- a/npm_and_yarn/spec/fixtures/github/contents_js_tar.json
+++ b/npm_and_yarn/spec/fixtures/github/contents_js_tar.json
@@ -1,0 +1,14 @@
+[
+    {
+      "name": "etag.tar",
+      "path": "deps/etag.tar",
+      "sha": "2393602fac96cfe31d64f89476014124b4a13b85",
+      "size": 19,
+      "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.deps/etag.tar?ref=master",
+      "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/master/.deps/etag.tar",
+      "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2393602fac96cfe31d64f89476014124b4a13b85",
+      "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/master/.deps/etag.tar",
+      "type": "file"
+    }
+  ]
+  

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_tar_path.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_tar_path.json
@@ -1,0 +1,19 @@
+{
+    "name": "package.json",
+    "path": "package.json",
+    "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+    "size": 594,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+    "type": "file",
+    "content": "ewogICJuYW1lIjogImJ1bXAtdGVzdCIsCiAgInZlcnNpb24iOiAiMC4wLjEiLAogICJkZXNjcmlwdGlvbiI6ICIiLAogICJkZXBlbmRlbmNpZXMiOiB7CiAgICAibG9kYXNoIjogIl4xLjMuMSIsCiAgICAiY2hhbGsiOiAiMC40LjAiLAogICAgInN0b3B3b3JkcyI6ICIwLjAuMSIKICB9LAogICJkZXZEZXBlbmRlbmNpZXMiOiB7CiAgICAiZXRhZyI6ICJmaWxlOi4vZGVwcy9ldGFnLnRhciIsCiAgICAiY29yZG92YS1wbHVnaW4tZ2VvbG9jYXRpb24iOiB7CiAgICAgICJHRU9MT0NBVElPTl9VU0FHRV9ERVNDUklQVElPTiI6ICJUbyBsb2NhdGUgeW91IgogICAgfQogIH0KfQo=",
+    "encoding": "base64",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+      "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+      "html": "https://github.com/gocardless/bump/blob/master/package.json"
+    }
+  }
+  


### PR DESCRIPTION
if a .tar extension file is given as path dependency in dependency files, dependabot failing to parse/handle. Handled the same tgz files are handled