### PR TITLE
Handle tags permission failure in PR creation

### DIFF
--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -81,6 +81,16 @@ module Dependabot
           labeler.labels_for_pr,
           work_item
         )
+      rescue *Clients::Azure::TagsCreationForbidden
+        # If the user doesn't have permissions to create tags, create PR without labels
+        azure_client_for_source.create_pull_request(
+          pr_name,
+          branch_name,
+          source.branch || default_branch,
+          pr_description,
+          [],
+          work_item
+        )
       end
 
       def default_branch

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -181,6 +181,39 @@ RSpec.describe Dependabot::Clients::Azure do
     end
   end
 
+  describe "#create_pull_request" do
+    subject { client.create_pull_request("pr_name", "source_branch", "target_branch",
+      "", [], nil) }
+
+    let(:pull_request_url) { repo_url + "/pullrequests?api-version=5.0" }
+    
+    context "when response is 403 & tags creation is forbidden" do
+      before do
+        stub_request(:post, pull_request_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 403, body: JSON.unparse({message: "TF401289: The current user does not have permissions to create tags"}))
+        
+      end
+  
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::TagsCreationForbidden)
+      end
+    end
+  
+    context "when response is 403" do
+      before do
+        stub_request(:post, pull_request_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 403, body: JSON.unparse({message: "User doesn't have create PR permission"}))
+      end
+  
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Forbidden)
+      end
+    end
+
+  end
+  
   describe "#pull_request" do
     subject { client.pull_request(pull_request_id) }
 


### PR DESCRIPTION
While creating PR in azure client, if the user doesn't have "Tags" create permission, the PR creation is also failing.
Fixing this issue by rescuing the "Tags" create permission exception and recalling the create PR without tags.