### PR TITLE
Enabling parsing of complex workspace glob patterns

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.24.0"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.75"
-  spec.add_dependency "faraday", "1.7.0"
+  #spec.add_dependency "faraday", "1.7.0"
   spec.add_dependency "gitlab", "4.17.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/shared_helpers"
 require "excon"
+require "cgi"
 
 module Dependabot
   module Clients
@@ -140,46 +141,49 @@ module Dependabot
         JSON.parse(response.body).fetch("value")
       end
 
-      def fetch_code_paths_for_search_text(search_text:)
+      def fetch_repo_paths_for_code_search(search_text)
         code_paths = []
-        skip = 0
-        top = 1000
+        current_page_number = 1
+        page_limit = 1000
 
+        # API documentation link: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.0
+        # This is a paginated API with page limit of 1000 records
+        # Hence we need to call the API iteratively for each page of records until all records are received.
         loop do
           content = {
             searchText: search_text,
-            "$skip": skip,
-            "$top": top,
+            "$skip": (current_page_number - 1) * page_limit,
+            "$top": page_limit,
             filters: {
               Project: [
-                "Outlook Web"
+                CGI.unescape(source.project)
               ],
               Repository: [
                 source.unscoped_repo
               ],
+              Path: [
+                source.directory
+              ],
               Branch: [
-                "master"
+                source.branch
               ]
             }
           }
 
           response = post("https://almsearch.dev.azure.com/" +
             source.organization + "/" + source.project +
-            "/_apis/search/codesearchresults?api-version=6.0-preview.1", content.to_json)
+            "/_apis/search/codesearchresults?api-version=6.0", content.to_json)
 
           response_json = JSON.parse(response.body)
+          total_result_count = response_json.fetch("count").to_i
+          fetched_results = response_json.fetch("results")
 
-          count = response_json.fetch("count").to_i
-
-          results = response_json.fetch("results")
-
-          results.each do |result|
+          fetched_results.each do |result|
             code_paths.append(result.fetch("path"))
           end
 
-          break if count <= skip + top
-
-          skip += top
+          break if total_result_count <= current_page_number * page_limit
+          current_page_number += 1
         end
 
         code_paths
@@ -219,8 +223,6 @@ module Dependabot
                               pr_description, labels, work_item = nil)
         pr_description = truncate_pr_description(pr_description)
 
-        puts "Create pull request from source: #{source_branch} to target: #{target_branch}"
-        puts "PR name:#{pr_name}"
         content = {
           sourceRefName: "refs/heads/" + source_branch,
           targetRefName: "refs/heads/" + target_branch,

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -141,7 +141,7 @@ module Dependabot
         JSON.parse(response.body).fetch("value")
       end
 
-      def fetch_repo_paths_for_code_search(search_text)
+      def fetch_repo_paths_for_code_search(search_text, directory)
         code_paths = []
         current_page_number = 1
         page_limit = 1000
@@ -162,7 +162,7 @@ module Dependabot
                 source.unscoped_repo
               ],
               Path: [
-                source.directory
+                directory
               ],
               Branch: [
                 source.branch

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -143,8 +143,7 @@ module Dependabot
 
       def fetch_repo_paths_for_code_search(search_text, directory)
         code_paths = []
-        current_page_number = 1
-        page_limit = 1000
+        current_page_number = 1, page_limit = 1000
 
         # API documentation link: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.0
         # This is a paginated API with page limit of 1000 records

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -146,6 +146,11 @@ module Dependabot
         current_page_number = 1
         page_limit = 1000
 
+        # If Dependabot::Source object is initialized with project/repo id(instead of name)
+        # Need to fetch the project and repo name since code search API project/repo filters do not work with ids.
+        repo_details = repository_details
+        repo_project_name = repo_details.fetch("project").fetch("name")
+        repo_name = repo_details.fetch("name")
         # API documentation link: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.0
         # This is a paginated API with page limit of 1000 records
         # Hence we need to call the API iteratively for each page of records until all records are received.
@@ -156,10 +161,10 @@ module Dependabot
             "$top": page_limit,
             filters: {
               Project: [
-                CGI.unescape(source.project)
+                CGI.unescape(repo_project_name)
               ],
               Repository: [
-                source.unscoped_repo
+                CGI.unescape(repo_name)
               ],
               Path: [
                 directory
@@ -175,11 +180,7 @@ module Dependabot
 
           response_json = JSON.parse(response.body)
           total_result_count = response_json.fetch("count").to_i
-          fetched_results = response_json.fetch("results")
-
-          fetched_results.each do |result|
-            code_paths.append(result.fetch("path"))
-          end
+          response_json.fetch("results").each { |result| code_paths.append(result.fetch("path")) }
 
           break if total_result_count <= current_page_number * page_limit
 
@@ -187,6 +188,18 @@ module Dependabot
         end
 
         code_paths
+      end
+
+      def repository_details
+        @repository_details ||=
+          begin
+            response = get(source.api_endpoint +
+              source.organization + "/" + source.project +
+              "/_apis/git/repositories/" + source.unscoped_repo +
+              "?api-version=6.0")
+
+            JSON.parse(response.body)
+          end
       end
 
       def create_commit(branch_name, base_commit, commit_message, files,

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -183,6 +183,7 @@ module Dependabot
           end
 
           break if total_result_count <= current_page_number * page_limit
+
           current_page_number += 1
         end
 

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -143,7 +143,8 @@ module Dependabot
 
       def fetch_repo_paths_for_code_search(search_text, directory)
         code_paths = []
-        current_page_number = 1, page_limit = 1000
+        current_page_number = 1
+        page_limit = 1000
 
         # API documentation link: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.0
         # This is a paginated API with page limit of 1000 records
@@ -169,8 +170,7 @@ module Dependabot
             }
           }
 
-          response = post("https://almsearch.dev.azure.com/" +
-            source.organization + "/" + source.project +
+          response = post("https://almsearch.dev.azure.com/" + source.organization + "/" + source.project +
             "/_apis/search/codesearchresults?api-version=6.0", content.to_json)
 
           response_json = JSON.parse(response.body)

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -145,7 +145,7 @@ module Dependabot
         skip = 0
         top = 1000
 
-        while true
+        loop do
           content = {
             searchText: search_text,
             "$skip": skip,
@@ -160,20 +160,20 @@ module Dependabot
               Branch: [
                 "master"
               ]
-            } 
+            }
           }
 
-          response = post("https://almsearch.dev.azure.com/" + 
-            source.organization + "/" + source.project + 
+          response = post("https://almsearch.dev.azure.com/" +
+            source.organization + "/" + source.project +
             "/_apis/search/codesearchresults?api-version=6.0-preview.1", content.to_json)
-          
+
           response_json = JSON.parse(response.body)
 
           count = response_json.fetch("count").to_i
 
           results = response_json.fetch("results")
 
-          for result in results
+          results.each do |result|
             code_paths.append(result.fetch("path"))
           end
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -153,8 +153,12 @@ module Dependabot
         raise Dependabot::DependencyFileNotFound, path
       end
 
-      def fetch_code_paths_for_search_text(search_text:)
-        azure_client.fetch_code_paths_for_search_text(search_text: search_text)
+      def fetch_repo_paths_for_code_search(search_text)
+        case source.provider
+        when "azure"
+          azure_client.fetch_repo_paths_for_code_search(search_text)
+        else raise "Code search currently not support for provider: '#{source.provider}'."
+        end
       end
 
       def repo_contents(dir: ".", ignore_base_directory: false,

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -157,7 +157,7 @@ module Dependabot
         case source.provider
         when "azure"
           azure_client.fetch_repo_paths_for_code_search(search_text)
-        else raise "Code search currently not support for provider: '#{source.provider}'."
+        else []
         end
       end
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -153,10 +153,10 @@ module Dependabot
         raise Dependabot::DependencyFileNotFound, path
       end
 
-      def fetch_repo_paths_for_code_search(search_text)
+      def fetch_repo_paths_for_code_search(search_text, directory)
         case source.provider
         when "azure"
-          azure_client.fetch_repo_paths_for_code_search(search_text)
+          azure_client.fetch_repo_paths_for_code_search(search_text, directory)
         else []
         end
       end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -153,6 +153,10 @@ module Dependabot
         raise Dependabot::DependencyFileNotFound, path
       end
 
+      def fetch_code_paths_for_search_text(search_text:)
+        azure_client.fetch_code_paths_for_search_text(search_text: search_text)
+      end
+
       def repo_contents(dir: ".", ignore_base_directory: false,
                         raise_errors: true, fetch_submodules: false)
         dir = File.join(directory, dir) unless ignore_base_directory

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Dependabot::Clients::Azure do
   end
 
   describe "#code_search" do
-    subject(:code_search) { client.fetch_repo_paths_for_code_search(search_text) }
+    subject(:code_search) { client.fetch_repo_paths_for_code_search(search_text, source.directory) }
 
     let(:source) {Dependabot::Source.new(provider: 'azure', repo: 'org/project/_git/repo', branch: 'main', directory: 'src')}
     let(:code_search_url) { "https://almsearch.dev.azure.com/" + source.organization + "/" + source.project + "/_apis/search/codesearchresults?api-version=6.0"}

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "dependabot/clients/azure"
+require "cgi"
 
 RSpec.shared_examples "#get using auth headers" do |credential|
   before do
@@ -297,6 +298,93 @@ RSpec.describe Dependabot::Clients::Azure do
                 to eq(new_commit_id)
             end
         )
+    end
+  end
+
+  describe "#code_search" do
+    subject(:code_search) { client.fetch_repo_paths_for_code_search(search_text) }
+
+    let(:source) {Dependabot::Source.new(provider: 'azure', repo: 'org/project/_git/repo', branch: 'main', directory: 'src')}
+    let(:code_search_url) { "https://almsearch.dev.azure.com/" + source.organization + "/" + source.project + "/_apis/search/codesearchresults?api-version=6.0"}
+    let(:search_text) {'package.json'}
+    let(:results) {[{"path" => "/src/folderA/package.json"}, {"path" => "/src/folderB/package.json"}, {"path" => "/src/folderC/package.json"}]}
+    let(:expected_code_paths) { ["/src/folderA/package.json", "/src/folderB/package.json", "/src/folderC/package.json"] }
+
+
+    context "when response code is 200" do
+
+      context "when the API returns results in multiple pages" do
+        before do
+          stub_request(:post, code_search_url).
+            with(basic_auth: [username, password], body: { 'searchText' => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [ CGI.unescape(source.project)], "Repository" => [ source.unscoped_repo ], "Path" => [source.directory],"Branch" => [ source.branch ]}}.to_json).
+            to_return({status: 200, body: {"count" => 1002, "results" => results[0, 2]}.to_json})
+
+          stub_request(:post, code_search_url).
+            with(basic_auth: [username, password], body: { 'searchText' => search_text, "$skip" => 1000, "$top" => 1000, "filters" => { "Project" => [ CGI.unescape(source.project)], "Repository" => [ source.unscoped_repo ], "Path" => [source.directory], "Branch" => [ source.branch ]}}.to_json).
+            to_return({status: 200, body: {"count" => 1002, "results" => results[2..-1]}.to_json})
+        end
+
+        it "calls the code search API multiple times to get fetch all results and return the code paths" do
+          code_paths = code_search
+
+          expect(WebMock).to (have_requested(:post, code_search_url).times(2))
+          expect(code_paths).to eq(expected_code_paths)
+        end
+      end
+
+      context "when the API returns results in single page" do
+        before do
+          stub_request(:post, code_search_url).
+            with(basic_auth: [username, password], body: { 'searchText' => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [ CGI.unescape(source.project)], "Repository" => [ source.unscoped_repo ], "Path" => [source.directory], "Branch" => [ source.branch ]}}.to_json).
+            to_return({status: 200, body: {"count" => 3, "results" => results}.to_json})
+        end
+
+        it "calls the code search API once to get all results and return the code paths" do
+          code_paths = code_search
+
+          expect(WebMock).to (have_requested(:post, code_search_url).times(1))
+          expect(code_paths).to eq(expected_code_paths)
+        end
+      end
+
+      context "when the API response contains number of results = 0" do
+        before do
+          stub_request(:post, code_search_url).
+            with(basic_auth: [username, password], body: { 'searchText' => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [ CGI.unescape(source.project)], "Repository" => [ source.unscoped_repo ], "Path" => [source.directory], "Branch" => [ source.branch ]}}.to_json).
+            to_return({status: 200, body: {"count" => 0, "results" => []}.to_json})
+        end
+
+        it "returns an empty array of code paths" do
+          code_paths = code_search
+
+          expect(WebMock).to (have_requested(:post, code_search_url).times(1))
+          expect(code_paths).to be_empty
+        end
+      end
+    end
+
+    context "when response is 401" do
+      before do
+        stub_request(:post, code_search_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 401)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Unauthorized)
+      end
+    end
+
+    context "when response is 404" do
+      before do
+        stub_request(:post, code_search_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 404)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::NotFound)
+      end
     end
   end
 

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -432,6 +432,18 @@ RSpec.describe Dependabot::Clients::Azure do
       end
     end
 
+    context "when response is 400" do
+      before do
+        stub_request(:post, code_search_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 400, body: { "message" => "Invalid Project" }.to_json)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::BadRequest, "Invalid Project")
+      end
+    end
+
     context "when response is 401" do
       before do
         stub_request(:post, code_search_url).

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -308,7 +308,9 @@ RSpec.describe Dependabot::Clients::Azure do
       Dependabot::Source.new(provider: "azure", repo: "org/project/_git/repo", branch: "main", directory: "src")
     end
     let(:code_search_url) do
-      "https://almsearch.dev.azure.com/" + source.organization + "/" + source.project + "/_apis/search/codesearchresults?api-version=6.0"
+      "https://almsearch.dev.azure.com/" +
+        source.organization + "/" + source.project +
+        "/_apis/search/codesearchresults?api-version=6.0"
     end
     let(:search_text) { "package.json" }
     let(:results) do
@@ -324,12 +326,34 @@ RSpec.describe Dependabot::Clients::Azure do
         before do
           stub_request(:post, code_search_url).
             with(basic_auth: [username,
-                              password], body: { "searchText" => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [CGI.unescape(source.project)], "Repository" => [source.unscoped_repo], "Path" => [source.directory], "Branch" => [source.branch] } }.to_json).
+                              password],
+                 body: {
+                   "searchText" => search_text,
+                   "$skip" => 0,
+                   "$top" => 1000,
+                   "filters" => {
+                     "Project" => [CGI.unescape(source.project)],
+                     "Repository" => [source.unscoped_repo],
+                     "Path" => [source.directory],
+                     "Branch" => [source.branch]
+                   }
+                 }.to_json).
             to_return({ status: 200, body: { "count" => 1002, "results" => results[0, 2] }.to_json })
 
           stub_request(:post, code_search_url).
             with(basic_auth: [username,
-                              password], body: { "searchText" => search_text, "$skip" => 1000, "$top" => 1000, "filters" => { "Project" => [CGI.unescape(source.project)], "Repository" => [source.unscoped_repo], "Path" => [source.directory], "Branch" => [source.branch] } }.to_json).
+                              password],
+                 body: {
+                   "searchText" => search_text,
+                   "$skip" => 1000,
+                   "$top" => 1000,
+                   "filters" => {
+                     "Project" => [CGI.unescape(source.project)],
+                     "Repository" => [source.unscoped_repo],
+                     "Path" => [source.directory],
+                     "Branch" => [source.branch]
+                   }
+                 }.to_json).
             to_return({ status: 200, body: { "count" => 1002, "results" => results[2..-1] }.to_json })
         end
 
@@ -345,7 +369,18 @@ RSpec.describe Dependabot::Clients::Azure do
         before do
           stub_request(:post, code_search_url).
             with(basic_auth: [username,
-                              password], body: { "searchText" => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [CGI.unescape(source.project)], "Repository" => [source.unscoped_repo], "Path" => [source.directory], "Branch" => [source.branch] } }.to_json).
+                              password],
+                 body: {
+                   "searchText" => search_text,
+                   "$skip" => 0,
+                   "$top" => 1000,
+                   "filters" => {
+                     "Project" => [CGI.unescape(source.project)],
+                     "Repository" => [source.unscoped_repo],
+                     "Path" => [source.directory],
+                     "Branch" => [source.branch]
+                   }
+                 }.to_json).
             to_return({ status: 200, body: { "count" => 3, "results" => results }.to_json })
         end
 
@@ -361,7 +396,18 @@ RSpec.describe Dependabot::Clients::Azure do
         before do
           stub_request(:post, code_search_url).
             with(basic_auth: [username,
-                              password], body: { "searchText" => search_text, "$skip" => 0, "$top" => 1000, "filters" => { "Project" => [CGI.unescape(source.project)], "Repository" => [source.unscoped_repo], "Path" => [source.directory], "Branch" => [source.branch] } }.to_json).
+                              password],
+                 body: {
+                   "searchText" => search_text,
+                   "$skip" => 0,
+                   "$top" => 1000,
+                   "filters" => {
+                     "Project" => [CGI.unescape(source.project)],
+                     "Repository" => [source.unscoped_repo],
+                     "Path" => [source.directory],
+                     "Branch" => [source.branch]
+                   }
+                 }.to_json).
             to_return({ status: 200, body: { "count" => 0, "results" => [] }.to_json })
         end
 

--- a/common/spec/fixtures/azure/repository_details.json
+++ b/common/spec/fixtures/azure/repository_details.json
@@ -1,0 +1,45 @@
+{
+	"id": "repo-id",
+	"name": "repo",
+	"url": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e",
+	"project": {
+		"id": "project-id",
+		"name": "project",
+		"description": "Test project"
+	},
+	"defaultBranch": "refs/heads/main",
+	"size": 8469699983,
+	"remoteUrl": "https://org@dev.azure.com/org/project/_git/repo",
+	"sshUrl": "git@ssh.dev.azure.com:v3/org/project/repo",
+	"webUrl": "https://dev.azure.com/org/project/_git/repo",
+	"_links": {
+		"self": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e"
+		},
+		"project": {
+			"href": "vstfs:///Classification/TeamProject/6e261f3b-5e35-4762-a6d6-14043c738628"
+		},
+		"web": {
+			"href": "https://dev.azure.com/org/project/_git/repo"
+		},
+		"ssh": {
+			"href": "git@ssh.dev.azure.com:v3/org/project/repo"
+		},
+		"commits": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/commits"
+		},
+		"refs": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/refs"
+		},
+		"pullRequests": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/pullRequests"
+		},
+		"items": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/items"
+		},
+		"pushes": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/pushes"
+		}
+	},
+	"isDisabled": false
+}

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -361,13 +361,26 @@ module Dependabot
           else [] # Invalid lerna.json, which must not be in use
           end
 
-        paths_array.flat_map do |path|
-          # The packages/!(not-this-package) syntax is unique to Yarn
-          if path.include?("*") || path.include?("!(")
-            expanded_paths(path)
-          else path
-          end
+      
+        workspace_directories = []
+        code_paths = fetch_code_paths_for_search_text(search_text: "package.json")
+        
+        for code_path in code_paths
+          next unless code_path.end_with?("/package.json") || !paths_array.any? { |path| File.fnmatch?(path, code_path)}
+          directory_path = code_path.chomp("/package.json")[1..-1]
+          workspace_directories.append(directory_path)
         end
+
+        workspace_directories
+
+
+        #paths_array.flat_map do |path|
+          # The packages/!(not-this-package) syntax is unique to Yarn
+          #if path.include?("*") || path.include?("!(")
+            #expanded_paths(path)
+          #else path
+          #end
+        #end
       end
 
       # Only expands globs one level deep, so path/**/* gets expanded to path/

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -370,7 +370,6 @@ module Dependabot
           ignored_paths = ignored_workspace_paths(paths_array)
 
           package_json_paths = fetch_all_package_jsons_repo_paths
-
           dir = directory.gsub(%r{(^/|/$)}, "")
 
           package_json_paths.each do |package_json_path|
@@ -384,11 +383,10 @@ module Dependabot
             next unless paths_array.any? { |path| !path.include?("!(") && File.fnmatch?(path, package_json_path) } && ignored_paths.none? { |path| File.fnmatch?(path, package_json_path)}
 
             # Since we want only the directory path, remove package.json from the package_json_path
-            workspace_directory_path = package_json_path.chomp("/package.json")
-            workspace_directories.append(workspace_directory_path)
+            workspace_directories.append(package_json_path.chomp("/package.json"))
           end
 
-          return workspace_directories
+          return workspace_directories unless workspace_directories.empty?
         end
 
         paths_array.flat_map do |path|
@@ -431,9 +429,11 @@ module Dependabot
 
           paths.each do |path|
             # Expands regex to add individual directory regexes
-            ignored_workspace_paths.append(path.gsub(/!\(.*?\)/, i))
+            ignored_workspace_paths.append(ignored_path.gsub(/!\(.*?\)/, path))
           end
         end
+
+        ignored_workspace_paths
       end
 
       def parsed_package_json

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -411,9 +411,9 @@ module Dependabot
       def fetch_all_workspace_package_jsons_repo_paths
         dir = directory.gsub(%r{(^/|/$)}, "")
 
-        fetch_repo_paths_for_code_search("package.json")
+        fetch_repo_paths_for_code_search("package.json", directory)
           # Check if the path is for a package.json file and starts with the source repo directory
-          .filter{|repo_path| repo_path.end_with?("/package.json") && repo_path.scan(%r{^/?#{Regexp.escape(dir)}\//?}).any?}
+          .filter{|repo_path| repo_path.end_with?("/package.json")}
           # Return path relative to repo source directory
           .map {|package_json_path| package_json_path.gsub(%r{^/?#{Regexp.escape(dir)}/?}, "")}
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -361,27 +361,26 @@ module Dependabot
           else [] # Invalid lerna.json, which must not be in use
           end
 
-      
         workspace_directories = []
         code_paths = fetch_code_paths_for_search_text(search_text: "package.json")
-        
-        for code_path in code_paths
+
+        code_paths.each do |code_path|
           p = code_path[1..-1]
-          next unless p.end_with?("/package.json") && paths_array.any? { |path| File.fnmatch?(path, p)}
+          next unless p.end_with?("/package.json") && paths_array.any? { |path| File.fnmatch?(path, p) }
+
           directory_path = p.chomp("/package.json")
           workspace_directories.append(directory_path)
         end
 
         workspace_directories
 
-
-        #paths_array.flat_map do |path|
-          # The packages/!(not-this-package) syntax is unique to Yarn
-          #if path.include?("*") || path.include?("!(")
-            #expanded_paths(path)
-          #else path
-          #end
-        #end
+        # paths_array.flat_map do |path|
+        # The packages/!(not-this-package) syntax is unique to Yarn
+        # if path.include?("*") || path.include?("!(")
+        # expanded_paths(path)
+        # else path
+        # end
+        # end
       end
 
       # Only expands globs one level deep, so path/**/* gets expanded to path/

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -407,12 +407,18 @@ module Dependabot
         package_json_paths = fetch_all_workspace_package_jsons_repo_paths
 
         package_json_paths.each do |package_json_path|
-          # If it does not match any of the specified workspaces or is an excluded workspace, skip that package path.
-          next unless ignored_paths.none? { |ignored_path| File.fnmatch?(ignored_path, package_json_path) }
-          next unless paths_array.any? { |path| !path.include?("!(") && File.fnmatch?(path, package_json_path) }
-
           # Since we want only the directory path, remove package.json from the package_json_path
-          workspace_directories.append(package_json_path.chomp("/package.json"))
+          workspace_directory_path = package_json_path.chomp("/package.json")
+
+          # If it does not match any of the specified workspaces or is an excluded workspace, skip that workspace path.
+          next unless ignored_paths.none? do |ignored_path|
+                        File.fnmatch?(ignored_path, workspace_directory_path, File::FNM_PATHNAME)
+                      end
+          next unless paths_array.any? do |path|
+                        !path.include?("!(") && File.fnmatch?(path, workspace_directory_path, File::FNM_PATHNAME)
+                      end
+
+          workspace_directories.append(workspace_directory_path)
         end
 
         workspace_directories

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -366,8 +366,9 @@ module Dependabot
         code_paths = fetch_code_paths_for_search_text(search_text: "package.json")
         
         for code_path in code_paths
-          next unless code_path.end_with?("/package.json") || !paths_array.any? { |path| File.fnmatch?(path, code_path)}
-          directory_path = code_path.chomp("/package.json")[1..-1]
+          p = code_path[1..-1]
+          next unless p.end_with?("/package.json") && paths_array.any? { |path| File.fnmatch?(path, p)}
+          directory_path = p.chomp("/package.json")
           workspace_directories.append(directory_path)
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -362,7 +362,8 @@ module Dependabot
           end
 
         # Currently, for complex glob patterns like packages/**/*, */packages/**,
-        # it is difficult to fetch workspace packages without local repo clone,
+        # it is not possible to fetch workspace packages without local repo clone,
+        # (See `expanded_paths` function declaration in this file for more details).
         # Hence, the idea is to fetch all the package.json paths in the repo and then
         # match it with the specified workspace glob patterns.
         complex_glob_pattern_present = paths_array.any? do |globbed_path|
@@ -411,9 +412,7 @@ module Dependabot
           workspace_directory_path = package_json_path.chomp("/package.json")
 
           # If it does not match any of the specified workspaces or is an excluded workspace, skip that workspace path.
-          next unless ignored_paths.none? do |ignored_path|
-                        File.fnmatch?(ignored_path, workspace_directory_path, File::FNM_PATHNAME)
-                      end
+          next unless ignored_paths.none? { |path| File.fnmatch?(path, workspace_directory_path, File::FNM_PATHNAME) }
           next unless paths_array.any? do |path|
                         !path.include?("!(") && File.fnmatch?(path, workspace_directory_path, File::FNM_PATHNAME)
                       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1243,15 +1243,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       end
 
       context "specified using complex glob pattern like packages/**/*" do
-        let(:package_json_code_search_results) {
+        let(:package_json_code_search_results) do
           [
-            '/packages/folderA/subfolderA/packageA/package.json',
-            '/packages/folderA/subfolderB/packageA/package.json',
-            '/packages/folderB/subfolderA/packageA/package1.json',
-            '/paster/folderA/subfolderA/packageA/package.json',
-            '/packages1/folderA/subfolderA/packageA/package2.json'
+            "/packages/folderA/subfolderA/packageA/package.json",
+            "/packages/folderA/subfolderB/packageA/package.json",
+            "/packages/folderB/subfolderA/packageA/package1.json",
+            "/paster/folderA/subfolderA/packageA/package.json",
+            "/packages1/folderA/subfolderA/packageA/package2.json"
           ]
-        }
+        end
 
         before do
           stub_request(:get, File.join(url, "package.json?ref=sha")).
@@ -1263,27 +1263,28 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
               headers: json_header
             )
 
-            stub_request(
-              :get,
-              File.join(url, "packages/folderA/subfolderA/packageA/package.json?ref=sha")
-            ).with(headers: { "Authorization" => "token token" }).
-              to_return(
-                status: 200,
-                body: fixture("github", "package_json_content.json"),
-                headers: json_header
-              )
+          stub_request(
+            :get,
+            File.join(url, "packages/folderA/subfolderA/packageA/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
 
-            stub_request(
-              :get,
-              File.join(url, "packages/folderA/subfolderB/packageA/package.json?ref=sha")
-            ).with(headers: { "Authorization" => "token token" }).
-              to_return(
-                status: 200,
-                body: fixture("github", "package_json_content.json"),
-                headers: json_header
-              )
+          stub_request(
+            :get,
+            File.join(url, "packages/folderA/subfolderB/packageA/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
 
-          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with('package.json').and_return(package_json_code_search_results)
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with("package.json",
+                                                                                          source.directory).and_return(package_json_code_search_results)
         end
 
         it "fetches package.json from the workspace dependencies" do
@@ -1309,7 +1310,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
             )
           expect(file_fetcher_instance.files.count).to eq(3)
           expect(file_fetcher_instance.files.map(&:name)).
-          not_to include("packages/folderA/subfolderB/packageA/package.json")
+            not_to include("packages/folderA/subfolderB/packageA/package.json")
         end
 
         it "tries to package.json from condensed glob pattern in case no workspace paths are detected via code search" do
@@ -1321,7 +1322,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
               headers: json_header
             )
 
-          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with('package.json').and_return([])
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with("package.json",
+                                                                                          source.directory).and_return([])
 
           expect(file_fetcher_instance.files.map(&:name)).
             to match_array(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1283,8 +1283,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
               headers: json_header
             )
 
-          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with("package.json",
-                                                                                          source.directory).and_return(package_json_code_search_results)
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).
+            with("package.json", source.directory).
+            and_return(package_json_code_search_results)
         end
 
         it "fetches package.json from the workspace dependencies" do
@@ -1313,7 +1314,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
             not_to include("packages/folderA/subfolderB/packageA/package.json")
         end
 
-        it "tries to package.json from condensed glob pattern in case no workspace paths are detected via code search" do
+        it "tries to fetch package.json from condensed glob pattern in case no paths are detected via code search" do
           stub_request(:get, File.join(url, "packages?ref=sha")).
             with(headers: { "Authorization" => "token token" }).
             to_return(
@@ -1322,8 +1323,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
               headers: json_header
             )
 
-          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with("package.json",
-                                                                                          source.directory).and_return([])
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).
+            with("package.json", source.directory).
+            and_return([])
 
           expect(file_fetcher_instance.files.map(&:name)).
             to match_array(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1242,6 +1242,97 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         end
       end
 
+      context "specified using complex glob pattern like packages/**/*" do
+        let(:package_json_code_search_results) {
+          [
+            '/packages/folderA/subfolderA/packageA/package.json',
+            '/packages/folderA/subfolderB/packageA/package.json',
+            '/packages/folderB/subfolderA/packageA/package1.json',
+            '/paster/folderA/subfolderA/packageA/package.json',
+            '/packages1/folderA/subfolderA/packageA/package2.json'
+          ]
+        }
+
+        before do
+          stub_request(:get, File.join(url, "package.json?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "package_json_with_complex_workspaces.json"),
+              headers: json_header
+            )
+
+            stub_request(
+              :get,
+              File.join(url, "packages/folderA/subfolderA/packageA/package.json?ref=sha")
+            ).with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: fixture("github", "package_json_content.json"),
+                headers: json_header
+              )
+
+            stub_request(
+              :get,
+              File.join(url, "packages/folderA/subfolderB/packageA/package.json?ref=sha")
+            ).with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: fixture("github", "package_json_content.json"),
+                headers: json_header
+              )
+
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with('package.json').and_return(package_json_code_search_results)
+        end
+
+        it "fetches package.json from the workspace dependencies" do
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(
+              %w(
+                package.json
+                package-lock.json
+                packages/folderA/subfolderA/packageA/package.json
+                packages/folderA/subfolderB/packageA/package.json
+              )
+            )
+        end
+
+        it "ignores excluded workspaces while fetching package.json from workspace dependencies" do
+          stub_request(:get, File.join(url, "package.json?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "package_json_with_complex_and_exclusion_workspaces.json"),
+              headers: json_header
+            )
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+          not_to include("packages/folderA/subfolderB/packageA/package.json")
+        end
+
+        it "tries to package.json from condensed glob pattern in case no workspace paths are detected via code search" do
+          stub_request(:get, File.join(url, "packages?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "packages_files.json"),
+              headers: json_header
+            )
+
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).with('package.json').and_return([])
+
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(
+              %w(
+                package.json
+                package-lock.json
+              )
+            )
+        end
+      end
+
       context "specified using a hash" do
         before do
           stub_request(:get, File.join(url, "package.json?ref=sha")).

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_complex_and_exclusion_workspaces.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_complex_and_exclusion_workspaces.json
@@ -1,0 +1,18 @@
+{
+    "name": "package.json",
+    "path": "package.json",
+    "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+    "size": 594,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+    "type": "file",
+    "content": "ewoibmFtZSI6ICJUZXN0IHJlcG8iLAoidmVyc2lvbiI6ICIzLjAuMCIsCiJkZXNjcmlwdGlvbiI6ICJUaGUgbmV4dCB2ZXJzaW9uIG9mIHRlc3QgcmVwbywgd3JpdHRlbiBpbiBUeXBlc2NyaXB0IiwKIm1haW4iOiAiaW5kZXguanMiLAoiYXV0aG9yIjogIlhZWiIsCiJsaWNlbnNlIjogIlVOTElDRU5TRUQiLAoicHJpdmF0ZSI6IHRydWUsCiJ3b3Jrc3BhY2VzIjogWyJwYWNrYWdlcy8qKi8qIiwgInBhY2thZ2VzLyovIShzdWJmb2xkZXJCKS8qIl0KfQ==",
+    "encoding": "base64",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+      "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+      "html": "https://github.com/gocardless/bump/blob/master/package.json"
+    }
+  }

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_complex_workspaces.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_complex_workspaces.json
@@ -1,0 +1,18 @@
+{
+  "name": "package.json",
+  "path": "package.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "ewoibmFtZSI6ICJUZXN0IHJlcG8iLAoidmVyc2lvbiI6ICIzLjAuMCIsCiJkZXNjcmlwdGlvbiI6ICJUaGUgbmV4dCB2ZXJzaW9uIG9mIHRlc3QgcmVwbywgd3JpdHRlbiBpbiBUeXBlc2NyaXB0IiwKIm1haW4iOiAiaW5kZXguanMiLAoiYXV0aG9yIjogIlhZWiIsCiJsaWNlbnNlIjogIlVOTElDRU5TRUQiLAoicHJpdmF0ZSI6IHRydWUsCiJ3b3Jrc3BhY2VzIjogWyJwYWNrYWdlcy8qKi8qIl0KfQ==",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/package.json"
+  }
+}


### PR DESCRIPTION
Currently, dependabot only understand workspaces defined in `package.json` using simpler regexes like `packages/*`, `packages/folder/*`, `abcd`. However, some large monorepos define workspaces with regexes like `packages/**/*`,`*/packages/*` which with the current logic would not be supported and hence not included in dependency update process and the created PR.

Solution (**This currently only works for AzureDevOps repos**) - 
For repos having complex workspace regexes, using this ADO code search REST API: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.1 (works in a similar that we use the code search feature in AzureDevOps UI), we can get the references for “package.json” string in the entire repo in a given repo path. For every code path result obtained in this search, we can do these two checks – 
1)	Check if the path is for a “package.json” file and lies in the given repo source directory
2)	Check if the path satisfies any of the workspace regexes mentioned in the package.json

If both of the conditions are met, then we will include this path while updating any dependency and also fetch its `package.json` in the file fetcher phase.

**Drawback** - The Code search API by default works only on the repo default branch unless the code search feature is enabled for a particular branch in the repo policies in AzureDevOps

Therefore, in case of repo clients other than ADO and for branches on which code search feature is not enabled in case of ADO repos, we will fallback to the old logic of condensing the workspace regex to simpler form in case of complex glob pattern

For repos which don't have any complex workspace regexes and all workspace patterns are of the form packages/folder1/folder2.../* or simpler (i.e exact workspace directory is specified), we will still use the old logic present in dependabot


