### PR TITLE
Updating Dockerfile.lite to support npm7 repos

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -68,7 +68,10 @@ RUN apt-add-repository ppa:brightbox/ruby-ng \
 
 # Install Node 14.0 and npm and yarn
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && apt-get install -y nodejs
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g npm@v7.21.0 \
+  && rm -rf ~/.npm
 
 # Copy src for only the gems we need.
 COPY npm_and_yarn/ /opt/npm_and_yarn/


### PR DESCRIPTION
## Issue
Currently, ms-dependabot treats repos using npm7+ as npm6 and updates the lockfile according to npm6 update even thought dependabot-core has code support for identifying npm7 repos and handling updates for those repos accordingly.

## Cause
To identify or run updates on npm7+ based repos, `dependabot-core` requires npm7 to be installed in the docker container however the `Dockerfile.lite` (which is used as base image in ms-dependabot) only installs node 14 (which inherently install npm 6). Hence, even with code support, the update does not work as expected for npm7 repos.

## Solution
Updated the `Dockerfile.lite` to install npm version: `7.21.0` explicitly along with node 14 (which brings npm 6). This is in accordance with the `Dockerfile` which is used by dependabot-core as the base image (Check here: https://github.com/GiriB/dependabot-core/blob/azure_changes/Dockerfile#L74)

**NOTE:** To avoid such situations in the future: We can add an additional step in the github CI pipeline which runs tests on `Dockerfile.lite` base image