### PR TITLE
Updating extraction of workspace directory path for complex glob patterns

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -410,7 +410,7 @@ module Dependabot
 
         package_json_paths.each do |package_json_path|
           # Since we want only the directory path, remove package.json from the package_json_path
-          workspace_directory_path = package_json_path.chomp("/package.json")
+          workspace_directory_path = package_json_path.chomp("package.json").chomp("/")
 
           # If it does not match any of the specified workspaces or is an excluded workspace, skip that workspace path.
           next unless ignored_paths.none? { |path| File.fnmatch?(path, workspace_directory_path, File::FNM_PATHNAME) }


### PR DESCRIPTION
For cases where workspace glob-patterns contains `'**'`, it matches with the root package.json as well. However, currently, the way we extract the workspace directory path i.e by removing the substring `/package.json` from the end -> in case of the root package.json it won't match as the package_json_path would be = `package.json` only. Hence it would consider `package.json` as the workspace directory path and then add `package.json` string at the end to it to fetch the package.json file for that workspace. So the path to the workspace package.json would be like `package.json\package.json` which is incorrect.

## How this issue causes failure?
Before fetching the `package.json` for the workspace, it tries fetching the tree root structure for the workspace directory but since in this case the workspace directory comes out to be the root package.json file path rather than the directory path because of the bug, the API returns the package.json content instead of the expected response containing `objectId` field - https://github.com/GiriB/dependabot-core/blob/azure_changes/common/lib/dependabot/clients/azure.rb#L99 and hence the job fails with error: `key not found: "objectId"`
