### PR TITLE
Fix random response order from AzureDevOps code search API

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -162,6 +162,12 @@ module Dependabot
             searchText: search_text,
             "$skip": (current_page_number - 1) * page_limit,
             "$top": page_limit,
+            "$orderBy": [
+              {
+                field: "path",
+                sortOrder: "ASC"
+              }
+            ],
             filters: {
               Project: [CGI.unescape(repo_project_name)],
               Repository: [CGI.unescape(repo_name)],

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -343,6 +343,12 @@ RSpec.describe Dependabot::Clients::Azure do
                    "searchText" => search_text,
                    "$skip" => 0,
                    "$top" => 1000,
+                   "$orderBy": [
+                     {
+                       field: "path",
+                       sortOrder: "ASC"
+                     }
+                   ],
                    "filters" => {
                      "Project" => [CGI.unescape(project_name)],
                      "Repository" => [CGI.unescape(repo_name)],
@@ -359,6 +365,12 @@ RSpec.describe Dependabot::Clients::Azure do
                    "searchText" => search_text,
                    "$skip" => 1000,
                    "$top" => 1000,
+                   "$orderBy": [
+                     {
+                       field: "path",
+                       sortOrder: "ASC"
+                     }
+                   ],
                    "filters" => {
                      "Project" => [CGI.unescape(project_name)],
                      "Repository" => [CGI.unescape(repo_name)],
@@ -386,6 +398,12 @@ RSpec.describe Dependabot::Clients::Azure do
                    "searchText" => search_text,
                    "$skip" => 0,
                    "$top" => 1000,
+                   "$orderBy": [
+                     {
+                       field: "path",
+                       sortOrder: "ASC"
+                     }
+                   ],
                    "filters" => {
                      "Project" => [CGI.unescape(project_name)],
                      "Repository" => [CGI.unescape(repo_name)],
@@ -413,6 +431,12 @@ RSpec.describe Dependabot::Clients::Azure do
                    "searchText" => search_text,
                    "$skip" => 0,
                    "$top" => 1000,
+                   "$orderBy": [
+                     {
+                       field: "path",
+                       sortOrder: "ASC"
+                     }
+                   ],
                    "filters" => {
                      "Project" => [CGI.unescape(project_name)],
                      "Repository" => [CGI.unescape(repo_name)],


### PR DESCRIPTION
Earlier, without the `orderBy` field in the request body for calling the code search API in the `azure` client class, the response would be returned in a random order and hence it would contain duplicates in case the code search API is called more than once if the count of the results expands more than 1 page(s).
This caused frequent failures related to `package not found errors` like `PrivateSourceAuthenticationFailure`, `FileNotResolvable` errors as package.json files for some of the internal packages were not downloaded.

## How the issue is fixed
We are now passing expecting the results to be ordered in ASC order on the basis of their path using the `orderBy` field in the code search API request. This will ensure that the results across multiple code search API calls are consistent and there are no duplicates