### PR TITLE
Adding authenticated user details as author while creating commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -209,6 +209,11 @@ module Dependabot
 
       def create_commit(branch_name, base_commit, commit_message, files,
                         author_details)
+
+        if author_details.nil?
+          author_details = { name: authenticated_user, email: "#{authenticated_user}@microsoft.com" }
+        end
+
         content = {
           refUpdates: [
             { name: "refs/heads/" + branch_name, oldObjectId: base_commit }
@@ -278,6 +283,16 @@ module Dependabot
                         "/refs?api-version=5.0", content.to_json)
 
         JSON.parse(response.body).fetch("value").first
+      end
+
+      def authenticated_user
+        @authenticated_user ||=
+        begin
+          response = get(source.api_endpoint +
+            source.organization + '/_apis/connectiondata')
+
+          JSON.parse(response.body).fetch('authenticatedUser').fetch('providerDisplayName')
+        end
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Dependabot::Clients::Azure do
     end
 
     let(:commit_url) { repo_url + "/pushes?api-version=5.0" }
-    let(:authenticated_user_details_url) { source.api_endpoint + source.org + '/_apis/connectiondata'}
+    let(:authenticated_user_details_url) { source.api_endpoint + source.organization + "/_apis/connectiondata" }
 
     context "when response is 403" do
       let(:author_details) do
@@ -146,7 +146,10 @@ RSpec.describe Dependabot::Clients::Azure do
       end
 
       context "when author_details is nil" do
-        let(:author_details) { name: "XYZ", email: "XYZ@microsoft.com" }
+        let(:author_details) do
+          { name: "XYZ", email: "XYZ@microsoft.com" }
+        end
+
         it "pushes commit with authenticated user details as the author property" do
           create_commit
 
@@ -553,27 +556,27 @@ RSpec.describe Dependabot::Clients::Azure do
     end
   end
 
-  desribe "#autheticated_user" do
+  describe "#authenticated_user" do
     subject(:authenticated_user) { client.authenticated_user }
-    let(:authenticated_user_details_url) { source.api_endpoint + source.org + '/_apis/connectiondata'}
+    let(:authenticated_user_details_url) { source.api_endpoint + source.organization + "/_apis/connectiondata" }
 
     context "when response code is 200" do
       response_body = fixture("azure", "authenticated_user_details.json")
 
       before do
-        stub_request(:get, authenticated_user_url).
+        stub_request(:get, authenticated_user_details_url).
           with(basic_auth: [username, password]).
           to_return({ status: 200, body: response_body })
       end
 
-      let(:authenticated_user_name) { 'XYZ' }
+      let(:authenticated_user_name) { "XYZ" }
 
       it "returns the repo details" do
-        authenticated_user = authenticated_user
+        authenticated_user_details = authenticated_user
 
         # Expect
-        expect(authenticated_user).not_to be_nil
-        expect(authenticated_user).to eq(authenticated_user_name)
+        expect(authenticated_user_details).not_to be_nil
+        expect(authenticated_user_details).to eq(JSON.parse(response_body).fetch("authenticatedUser"))
       end
     end
 

--- a/common/spec/fixtures/azure/authenticated_user_details.json
+++ b/common/spec/fixtures/azure/authenticated_user_details.json
@@ -1,0 +1,41 @@
+{
+    "authenticatedUser": {
+      "id": "854e434d-b904-664a-b566-2d668372940c",
+      "descriptor": "Microsoft.IdentityModel.Claims.ClaimsIdentity;72f988bf-86f1-41af-91ab-2d7cd011db47\\xyz@microsoft.com",
+      "subjectDescriptor": "aad.ODU0ZTQzNGQtYjkwNC03NjRhLWI1NjYtMmQ2NjgzNzI5NDBj",
+      "providerDisplayName": "XYZ",
+      "isActive": true,
+      "properties": {
+        "Account": {
+          "$type": "System.String",
+          "$value": "xyz@microsoft.com"
+        }
+      },
+      "resourceVersion": 2,
+      "metaTypeId": 0
+    },
+    "authorizedUser": {
+      "id": "854e434d-b904-664a-b566-2d668372940c",
+      "descriptor": "Microsoft.IdentityModel.Claims.ClaimsIdentity;72f988bf-86f1-41af-91ab-2d7cd011db47\\xyz@microsoft.com",
+      "subjectDescriptor": "aad.ODU0ZTQzNGQtYjkwNC03NjRhLWI1NjYtMmQ2NjgzNzI5NDBj",
+      "providerDisplayName": "XYZ",
+      "isActive": true,
+      "properties": {
+        "Account": {
+          "$type": "System.String",
+          "$value": "xyz@microsoft.com"
+        }
+      },
+      "resourceVersion": 2,
+      "metaTypeId": 0
+    },
+    "instanceId": "a2fba5bb-e91f-4218-8d9f-3ba6468216b4",
+    "deploymentId": "76e9b14b-0007-5685-a969-1a5852267453",
+    "deploymentType": "hosted",
+    "locationServiceData": {
+      "serviceOwner": "00025394-6065-48ca-87d9-7f5672854ef7",
+      "defaultAccessMappingMoniker": "PublicAccessMapping",
+      "lastChangeId": 210137168,
+      "lastChangeId64": 210137168
+    }
+  }


### PR DESCRIPTION
In ADO, certain repos have `Commit author email validation` policy enabled which only allow accounts/identities having certain email regexes like *@microsoft.com, *@linkedin.com, etc. to create a commit in the repo (if the policy is enabled for the repo)

For certain identities in ADO like framework identities (which do not have an email id associated with them), this policy does not allow these identities to create a commit even after adding their name in the property of allowed identities for this policy.

To prevent this, we need to pass the identity details in the `"author"` property while sending a create commit request. This PR gets the details for the authenticated user and adds them in the `"author"` property for the `create_commit` ADO request.